### PR TITLE
Set session info to account data

### DIFF
--- a/src/icq/mod.rs
+++ b/src/icq/mod.rs
@@ -1,3 +1,3 @@
 mod client;
-mod protocol;
+pub mod protocol;
 pub mod system;

--- a/src/icq/protocol.rs
+++ b/src/icq/protocol.rs
@@ -96,7 +96,7 @@ pub async fn start_session(registration_data: &RegistrationData) -> Result<Sessi
         client_name: "webicq",
         language: LANGUAGE,
         device_id: &device_id(),
-        session_timeout: 2592000,
+        session_timeout: 2_592_000,
         assert_caps: CAPS,
         interest_caps: "",
         events: EVENTS,

--- a/src/icq/system.rs
+++ b/src/icq/system.rs
@@ -1,7 +1,7 @@
 use super::protocol;
 use crate::messages::{AccountInfo, FdSender, ICQSystemHandle, PurpleMessage, SystemMessage};
-use crate::purple;
 use crate::Handle;
+use crate::{purple, AccountData};
 use async_std::sync::{channel, Receiver};
 
 const CHANNEL_CAPACITY: usize = 1024;
@@ -125,11 +125,12 @@ impl ICQSystem {
             let session_info = protocol::start_session(&registered_account_info).await;
             log::debug!("Session info: {:?}", session_info);
             match session_info {
-                Ok(_info) => {
+                Ok(session) => {
                     self.tx
                         .connection_proxy(&handle)
                         .set_state(purple::PurpleConnectionState::PURPLE_CONNECTED)
                         .await;
+                    *account_info.protocol_data.lock().await = Some(AccountData { session });
                 }
                 Err(error) => {
                     let error_message = format!("Failed to start session: {:?}", error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use async_std::sync::{Arc, Mutex};
 use lazy_static::lazy_static;
 use messages::{AccountInfo, ICQSystemHandle, PurpleMessage, SystemMessage};
 use purple::*;
@@ -14,13 +15,18 @@ lazy_static! {
     static ref ICON_FILE: CString = CString::new("icq").unwrap();
 }
 
-pub struct AccountData {}
+#[derive(Debug)]
+pub struct AccountData {
+    session: icq::protocol::SessionInfo,
+}
 
-pub type Handle = purple::Handle<AccountData>;
+pub type AccountDataBox = Arc<Mutex<Option<AccountData>>>;
+
+pub type Handle = purple::Handle<AccountDataBox>;
 
 struct PurpleICQ {
     system: ICQSystemHandle,
-    connections: purple::Connections<AccountData>,
+    connections: purple::Connections<AccountDataBox>,
     input_handle: Option<u32>,
 }
 
@@ -60,17 +66,21 @@ impl purple::PrplPlugin for PurpleICQ {
 impl purple::LoginHandler for PurpleICQ {
     fn login(&mut self, account: &mut Account) {
         // Safe as long as we remove the account in "close".
+        let protocol_data: AccountDataBox = Default::default();
         unsafe {
-            self.connections
-                .add(&mut account.get_connection().unwrap(), AccountData {})
+            self.connections.add(
+                &mut account.get_connection().unwrap(),
+                protocol_data.clone(),
+            )
         };
         let phone_number = account.get_username().unwrap().into();
         self.system
             .tx
-            .try_send(PurpleMessage::Login(AccountInfo::new(
-                Handle::from(account),
+            .try_send(PurpleMessage::Login(AccountInfo {
+                handle: Handle::from(account),
+                protocol_data,
                 phone_number,
-            )))
+            }))
             .unwrap();
     }
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -1,7 +1,7 @@
 use self::account_proxy::AccountProxy;
 use self::connection_proxy::ConnectionProxy;
 use crate::purple::{Account, Connection};
-use crate::Handle;
+use crate::{AccountDataBox, Handle};
 use async_std::sync::{Receiver, Sender};
 
 mod account_proxy;
@@ -46,16 +46,8 @@ impl FdSender<SystemMessage> {
 #[derive(Debug)]
 pub struct AccountInfo {
     pub handle: Handle,
+    pub protocol_data: AccountDataBox,
     pub phone_number: String,
-}
-
-impl AccountInfo {
-    pub fn new(handle: Handle, phone_number: String) -> Self {
-        Self {
-            handle,
-            phone_number,
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -43,11 +43,10 @@ impl FdSender<SystemMessage> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AccountInfo {
     pub handle: Handle,
     pub protocol_data: AccountDataBox,
-    pub phone_number: String,
 }
 
 #[derive(Debug)]

--- a/src/purple/connection/connections.rs
+++ b/src/purple/connection/connections.rs
@@ -17,7 +17,7 @@ impl<T> Connections<T> {
     pub unsafe fn add(&mut self, connection: &mut Connection, data: T) {
         let account = connection.get_account();
         let data_ptr = Box::new(ProtocolData::<T> {
-            account: account,
+            account,
             connection: connection.clone(),
             data,
         });
@@ -40,6 +40,6 @@ impl<T> Connections<T> {
         self.protocol_datas
             .get(&ptr.as_mut_ptr())
             .cloned()
-            .map(|p| unsafe { &mut *p.clone() })
+            .map(|p| unsafe { &mut *p })
     }
 }


### PR DESCRIPTION
@aviau !

Here's the threadsafe way to set session info to our purple account.

We could probably use the Arc pointer (`account_info.protocol_data`) in the polling task as well?