### PR TITLE
Load chat info on request and members list

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
                                      libsqlite3-dev libidn11-dev \
           && hg clone https://keep.imfreedom.org/pidgin/pidgin \
           && cd pidgin \
-          && hg up v2.13.0 \
+          && hg up v2.14.0 \
           && ./autogen.sh \
                   --prefix=/usr \
                   --disable-nm \

--- a/src/chat_info.rs
+++ b/src/chat_info.rs
@@ -1,0 +1,158 @@
+use super::{icq, purple};
+use lazy_static::lazy_static;
+use std::ffi::CString;
+
+lazy_static! {
+    pub static ref SN: CString = CString::new("sn").unwrap();
+    pub static ref SN_NAME: CString = CString::new("Chat ID").unwrap();
+    pub static ref STAMP: CString = CString::new("stamp").unwrap();
+    pub static ref TITLE: CString = CString::new("title").unwrap();
+    pub static ref GROUP: CString = CString::new("group").unwrap();
+    pub static ref STATE: CString = CString::new("state").unwrap();
+}
+
+const MEMBERS_VERSION: &str = "members_version";
+const INFO_VERSION: &str = "info_version";
+
+#[derive(Debug, Clone)]
+pub struct MemberRole(String);
+
+#[derive(Debug, Clone, Default)]
+pub struct PartialChatInfo {
+    pub sn: String,
+    pub title: String,
+    pub group: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ChatInfo {
+    pub stamp: Option<String>,
+    pub group: Option<String>,
+    pub sn: String,
+    pub title: String,
+    pub members_version: String,
+    pub info_version: String,
+    pub members: Vec<ChatMember>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChatMember {
+    pub sn: String,
+    pub friendly_name: Option<String>,
+    pub role: MemberRole,
+    pub last_seen: Option<u64>,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChatInfoVersion {
+    pub members_version: String,
+    pub info_version: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum ChatInfoVersionHandler {
+    Check(Option<ChatInfoVersion>),
+    DoNothing,
+}
+
+impl MemberRole {
+    pub fn as_flags(&self) -> purple::PurpleConvChatBuddyFlags {
+        match self.0.as_str() {
+            "admin" => purple::PurpleConvChatBuddyFlags::PURPLE_CBFLAGS_OP,
+            "readonly" => purple::PurpleConvChatBuddyFlags::PURPLE_CBFLAGS_NONE,
+            _ => purple::PurpleConvChatBuddyFlags::PURPLE_CBFLAGS_VOICE,
+        }
+    }
+}
+
+impl PartialChatInfo {
+    pub fn from_hashtable(table: &purple::StrHashTable) -> Option<Self> {
+        Some(Self {
+            group: table.lookup(&GROUP).map(Into::into),
+            sn: table.lookup(&SN)?.into(),
+            title: table.lookup(&TITLE)?.into(),
+        })
+    }
+
+    pub fn as_hashtable(&self) -> purple::StrHashTable {
+        let mut table = purple::StrHashTable::default();
+        table.insert(&SN, &self.sn);
+        if let Some(group) = &self.group {
+            table.insert(&GROUP, &group);
+        }
+        table.insert(&TITLE, &self.title);
+        table
+    }
+}
+
+impl ChatInfo {
+    pub fn as_partial(&self) -> PartialChatInfo {
+        PartialChatInfo {
+            sn: self.sn.clone(),
+            title: self.title.clone(),
+            group: self.group.clone(),
+        }
+    }
+
+    pub fn write_version_info(&self, node: &mut purple::BlistNode) {
+        node.set_string(MEMBERS_VERSION, &self.members_version);
+        node.set_string(INFO_VERSION, &self.info_version);
+    }
+}
+
+impl ChatInfoVersion {
+    pub fn need_update(&self, node: &mut purple::BlistNode) -> bool {
+        match node.get_string(MEMBERS_VERSION) {
+            None => return true,
+            Some(v) if v != self.members_version => return true,
+            _ => (),
+        };
+
+        match node.get_string(INFO_VERSION) {
+            None => return true,
+            Some(v) if v != self.info_version => return true,
+            _ => (),
+        };
+
+        false
+    }
+}
+
+impl From<icq::client::GetChatInfoResponseData> for ChatInfo {
+    fn from(info: icq::client::GetChatInfoResponseData) -> Self {
+        Self {
+            sn: info.sn,
+            stamp: Some(info.stamp),
+            title: info.name,
+            members_version: info.members_version,
+            info_version: info.info_version,
+            members: info
+                .members
+                .into_iter()
+                .map(|m| ChatMember {
+                    sn: m.sn,
+                    role: MemberRole(m.role),
+                    last_seen: m.user_state.last_seen.and_then(|t| match t {
+                        0 => None,
+                        t => Some(t),
+                    }),
+                    friendly_name: m.friendly,
+                    first_name: m.anketa.first_name,
+                    last_name: m.anketa.last_name,
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<icq::client::events::HistDlgStateMChatState> for ChatInfoVersion {
+    fn from(info: icq::client::events::HistDlgStateMChatState) -> Self {
+        Self {
+            members_version: info.members_version,
+            info_version: info.info_version,
+        }
+    }
+}

--- a/src/icq/client/events.rs
+++ b/src/icq/client/events.rs
@@ -198,6 +198,7 @@ pub struct HistDlgStateData {
     //pub unread_cnt: u32,
     pub messages: Vec<HistDlgStateMessage>,
     pub persons: Vec<HistDlgStatePerson>, // Information about the users involved in the messages.
+    pub mchat_state: Option<HistDlgStateMChatState>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -232,7 +233,7 @@ pub struct HistDlgStateMessage {
     //pub msg_id: String,
     pub time: i64,
     //pub locale: String,
-    pub text: String,
+    pub text: Option<String>,
     //pub media_type: String,
     pub chat: Option<HistDlgStateMessageChat>,
 }
@@ -249,4 +250,11 @@ pub struct HistDlgStateMessageChat {
     // pub live: Option<bool>
     pub sender: String, // The sender's sn
     pub name: String,   // The chat name
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HistDlgStateMChatState {
+    pub members_version: String,
+    pub info_version: String,
 }

--- a/src/icq/client/mod.rs
+++ b/src/icq/client/mod.rs
@@ -181,7 +181,10 @@ pub type GetChatInfoBody<'a> = RapiBody<'a, GetChatInfoBodyParams<'a>>;
 #[serde(rename_all = "camelCase")]
 pub struct GetChatInfoBodyParams<'a> {
     pub member_limit: u32,
-    pub stamp: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stamp: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sn: Option<&'a str>,
 }
 
 type GetChatInfoResponse = RapiResponse<GetChatInfoResponseData>;
@@ -204,18 +207,35 @@ pub struct GetChatInfoResponseData {
     //pub admins_count: usize,
     //pub default_role: String,
     //pub regions: String,
+    pub members_version: String,
+    pub info_version: String,
     pub sn: String,
     //pub abuse_reports_current_count: usize,
-    pub persons: Vec<ChatInfoResponsePerson>,
+    pub members: Vec<ChatInfoResponseMember>,
 }
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct ChatInfoResponsePerson {
+pub struct ChatInfoResponseMember {
     pub sn: String,
+    pub role: String,
+    #[serde(default)]
+    pub user_state: ChatInfoResponseMemberUserState,
+    pub friendly: Option<String>,
+    pub anketa: ChatInfoResponseMemberAnketa,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatInfoResponseMemberAnketa {
     pub first_name: Option<String>,
     pub last_name: Option<String>,
-    pub friendly: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+pub struct ChatInfoResponseMemberUserState {
+    #[serde(rename = "lastseen")]
+    pub last_seen: Option<u64>,
 }
 
 pub type JoinChatBody<'a> = RapiBody<'a, StampBodyParams<'a>>;

--- a/src/icq/mod.rs
+++ b/src/icq/mod.rs
@@ -1,4 +1,4 @@
-mod client;
+pub mod client;
 mod poller;
 pub mod protocol;
 pub mod system;

--- a/src/icq/protocol.rs
+++ b/src/icq/protocol.rs
@@ -12,8 +12,8 @@ const CAPS: &str = "094613584C7F11D18222444553540000,0946135C4C7F11D182224445535
 const EVENTS: &str = "myInfo,presence,buddylist,typing,hiddenChat,hist,mchat,sentIM,imState,dataIM,offlineIM,userAddedToBuddyList,service,lifestream,apps,permitDeny,diff,webrtcMsg";
 const PRESENCE_FIELDS: &str = "aimId,displayId,friendly,friendlyName,state,userType,statusMsg,statusTime,lastseen,ssl,mute,abContactName,abPhoneNumber,abPhones,official,quiet,autoAddition,largeIconId,nick,userState";
 
-type ChatInfo = client::GetChatInfoResponseData;
-type MsgInfo = client::SendIMResponseData;
+pub type ChatInfo = client::GetChatInfoResponseData;
+pub type MsgInfo = client::SendIMResponseData;
 
 #[derive(Debug)]
 pub enum Error {
@@ -138,13 +138,30 @@ pub async fn files_info(
         .map(|r| r.result)
 }
 
+pub async fn get_chat_info_by_sn(session: &SessionInfo, sn: &str) -> Result<ChatInfo> {
+    let get_chat_info_body = client::GetChatInfoBody {
+        aimsid: &session.aim_sid,
+        req_id: &request_id(),
+        params: client::GetChatInfoBodyParams {
+            member_limit: 50,
+            stamp: None,
+            sn: Some(sn),
+        },
+    };
+    client::get_chat_info(&get_chat_info_body)
+        .await
+        .map_err(Error::ApiError)
+        .map(|r| r.results)
+}
+
 pub async fn get_chat_info(session: &SessionInfo, stamp: &str) -> Result<ChatInfo> {
     let get_chat_info_body = client::GetChatInfoBody {
         aimsid: &session.aim_sid,
         req_id: &request_id(),
         params: client::GetChatInfoBodyParams {
             member_limit: 50,
-            stamp,
+            stamp: Some(stamp),
+            sn: None,
         },
     };
     client::get_chat_info(&get_chat_info_body)

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -85,15 +85,22 @@ pub struct SendMsgMessageData {
     pub message: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct GetChatInfoMessageData {
+    pub sn: String,
+}
+
 #[derive(Debug)]
 pub enum PurpleMessage {
     Login(AccountInfo),
     JoinChat(JoinChatMessage),
     SendMsg(SendMsgMessage),
+    GetChatInfo(GetChatInfoMessage),
 }
 
 pub type JoinChatMessage = PurpleMessageWithHandle<JoinChatMessageData>;
 pub type SendMsgMessage = PurpleMessageWithHandle<SendMsgMessageData>;
+pub type GetChatInfoMessage = PurpleMessageWithHandle<GetChatInfoMessageData>;
 
 impl PurpleMessage {
     pub fn join_chat(handle: Handle, protocol_data: AccountDataBox, stamp: String) -> Self {
@@ -114,6 +121,14 @@ impl PurpleMessage {
             handle,
             protocol_data,
             message_data: SendMsgMessageData { to_sn, message },
+        })
+    }
+
+    pub fn get_chat_info(handle: Handle, protocol_data: AccountDataBox, sn: String) -> Self {
+        Self::GetChatInfo(GetChatInfoMessage {
+            handle,
+            protocol_data,
+            message_data: GetChatInfoMessageData { sn },
         })
     }
 }

--- a/src/purple/account/mod.rs
+++ b/src/purple/account/mod.rs
@@ -1,5 +1,5 @@
 use super::ffi::{AsMutPtr, AsPtr};
-use super::{ChatConversation, Connection, PurpleConversationType};
+use super::{Connection, Conversation, PurpleConversationType};
 use std::borrow::Cow;
 use std::ffi::CStr;
 use std::ffi::CString;
@@ -15,6 +15,7 @@ impl AsMutPtr for Account {
     }
 }
 
+#[derive(Clone)]
 pub struct Account(*mut purple_sys::PurpleAccount);
 
 impl Account {
@@ -92,14 +93,14 @@ impl Account {
         settings::to_account(&self, settings)
     }
 
-    pub fn find_chat_conversation(&mut self, name: &str) -> Option<ChatConversation> {
+    pub fn find_chat_conversation(&mut self, name: &str) -> Option<Conversation> {
         let c_name = CString::new(name).unwrap();
         unsafe {
-            ChatConversation::from_ptr(purple_sys::purple_find_conversation_with_account(
+            Conversation::from_ptr(purple_sys::purple_find_conversation_with_account(
                 PurpleConversationType::PURPLE_CONV_TYPE_CHAT,
                 c_name.as_ptr(),
                 self.0,
-            ) as *mut purple_sys::PurpleConvChat)
+            ))
         }
     }
 

--- a/src/purple/connection/connections.rs
+++ b/src/purple/connection/connections.rs
@@ -14,11 +14,11 @@ impl<T> Connections<T> {
         }
     }
 
-    pub unsafe fn add(&mut self, connection: &mut Connection, data: T) {
+    pub unsafe fn add(&mut self, connection: Connection, data: T) {
         let account = connection.get_account();
         let data_ptr = Box::new(ProtocolData::<T> {
             account,
-            connection: connection.clone(),
+            connection,
             data,
         });
         let data_raw_ptr = Box::into_raw(data_ptr);
@@ -26,7 +26,7 @@ impl<T> Connections<T> {
         self.protocol_datas.insert(data_raw_ptr);
     }
 
-    pub fn remove(&mut self, connection: &mut Connection) {
+    pub fn remove(&mut self, connection: Connection) {
         let protocol_data_ptr = connection.get_protocol_data() as *mut ProtocolData<T>;
         self.protocol_datas.remove(&protocol_data_ptr);
         // Retake ownership of the protocol data to drop its data.

--- a/src/purple/conversation.rs
+++ b/src/purple/conversation.rs
@@ -1,69 +1,32 @@
 use super::ffi::{AsMutPtr, AsPtr};
-use super::Connection;
-use glib::translate::FromGlib;
+use super::{Connection, PurpleConvChatBuddyFlags};
+use glib::translate::{FromGlib, ToGlib};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
-use std::ptr::NonNull;
+use std::ptr::{null_mut, NonNull};
 
 pub struct ChatConversation(NonNull<purple_sys::PurpleConvChat>);
+pub struct Conversation(NonNull<purple_sys::PurpleConversation>);
 
-impl ChatConversation {
-    pub unsafe fn from_ptr(ptr: *mut purple_sys::PurpleConvChat) -> Option<Self> {
+impl Conversation {
+    pub unsafe fn from_ptr(ptr: *mut purple_sys::PurpleConversation) -> Option<Self> {
         NonNull::new(ptr).map(Self)
     }
 
     pub fn find(connection: &mut Connection, id: i32) -> Option<Self> {
-        unsafe {
-            Self::from_ptr(purple_sys::purple_find_chat(connection.as_mut_ptr(), id)
-                as *mut purple_sys::PurpleConvChat)
-        }
-    }
-
-    pub fn has_left(&mut self) -> bool {
-        FromGlib::from_glib(unsafe { purple_sys::purple_conv_chat_has_left(self.0.as_ptr()) })
-    }
-
-    pub fn present(&mut self) {
-        unsafe { purple_sys::purple_conversation_present(self.as_conversation_ptr()) }
-    }
-
-    pub fn set_data(&mut self, key: &str, data: &str) {
-        unsafe {
-            let c_key = CString::new(key).unwrap();
-            let c_data = CString::new(data).unwrap();
-            purple_sys::purple_conversation_set_data(
-                self.as_conversation_ptr(),
-                c_key.as_ptr(),
-                c_data.into_raw() as *mut c_void,
-            );
-        }
-    }
-
-    pub fn get_data(&mut self, key: &str) -> Option<&str> {
-        unsafe {
-            let c_key = CString::new(key).unwrap();
-            NonNull::new(purple_sys::purple_conversation_get_data(
-                self.as_conversation_ptr(),
-                c_key.as_ptr(),
-            ))
-            .map(|p| {
-                CStr::from_ptr(p.as_ptr() as *const c_char)
-                    .to_str()
-                    .unwrap()
-            })
-        }
+        unsafe { Self::from_ptr(purple_sys::purple_find_chat(connection.as_mut_ptr(), id)) }
     }
 
     pub fn set_title(&mut self, title: &str) {
         unsafe {
             let c_title = CString::new(title).unwrap();
-            purple_sys::purple_conversation_set_title(self.as_conversation_ptr(), c_title.as_ptr());
+            purple_sys::purple_conversation_set_title(self.as_mut_ptr(), c_title.as_ptr());
         }
     }
 
     pub fn get_title(&mut self) -> Option<&str> {
         unsafe {
-            let c_value = purple_sys::purple_conversation_get_title(self.as_conversation_ptr());
+            let c_value = purple_sys::purple_conversation_get_title(self.as_mut_ptr());
             NonNull::new(c_value as *mut c_char).map(|p| {
                 CStr::from_ptr(p.as_ptr() as *const c_char)
                     .to_str()
@@ -74,16 +37,125 @@ impl ChatConversation {
 
     pub fn get_connection(&mut self) -> Connection {
         unsafe {
-            let c_connection = purple_sys::purple_conversation_get_gc(self.as_conversation_ptr());
+            let c_connection = purple_sys::purple_conversation_get_gc(self.as_mut_ptr());
             Connection::from_raw(c_connection).unwrap()
         }
     }
 
-    pub fn as_conversation_ptr(&mut self) -> *mut purple_sys::PurpleConversation {
-        self.0.as_ptr() as *mut purple_sys::PurpleConversation
+    pub fn present(&mut self) {
+        unsafe { purple_sys::purple_conversation_present(self.as_mut_ptr()) }
+    }
+
+    // Unsafe since set_data check for an existing value and frees it as `T` type, while
+    // being unable to ensure the freed data is really ot `T` type.
+    pub unsafe fn set_data<T>(&mut self, key: &str, data: T) {
+        let c_key = CString::new(key).unwrap();
+        let existing_ptr =
+            purple_sys::purple_conversation_get_data(self.as_mut_ptr(), c_key.as_ptr());
+        if !existing_ptr.is_null() {
+            Box::<T>::from_raw(existing_ptr as *mut T);
+        }
+
+        let data_ptr = Box::into_raw(Box::new(data));
+        purple_sys::purple_conversation_set_data(
+            self.as_mut_ptr(),
+            c_key.as_ptr(),
+            data_ptr as *mut c_void,
+        );
+    }
+
+    // Unsafe since get_data doesn't validate the data stored at `key` is really of `T`
+    // type.
+    pub unsafe fn get_data<'a, T>(&'a mut self, key: &'_ str) -> Option<&'a mut T> {
+        let c_key = CString::new(key).unwrap();
+        NonNull::new(purple_sys::purple_conversation_get_data(
+            self.as_mut_ptr(),
+            c_key.as_ptr(),
+        ))
+        .map(|p| &mut *(p.as_ptr() as *mut T))
+    }
+
+    // Unsafe since it doesn't validate the data stored at `key` is really of `T`
+    // type.
+    pub unsafe fn remove_data<T>(&mut self, key: &str) {
+        let c_key = CString::new(key).unwrap();
+        let existing_ptr =
+            purple_sys::purple_conversation_get_data(self.as_mut_ptr(), c_key.as_ptr());
+        if !existing_ptr.is_null() {
+            Box::<T>::from_raw(existing_ptr as *mut T);
+            purple_sys::purple_conversation_set_data(self.as_mut_ptr(), c_key.as_ptr(), null_mut());
+        }
+    }
+
+    pub fn get_chat_data(&mut self) -> Option<ChatConversation> {
+        unsafe {
+            ChatConversation::from_ptr(purple_sys::purple_conversation_get_chat_data(
+                self.as_mut_ptr(),
+            ))
+        }
     }
 }
 
+impl ChatConversation {
+    pub unsafe fn from_ptr(ptr: *mut purple_sys::PurpleConvChat) -> Option<Self> {
+        NonNull::new(ptr).map(Self)
+    }
+
+    pub fn has_left(&mut self) -> bool {
+        FromGlib::from_glib(unsafe { purple_sys::purple_conv_chat_has_left(self.0.as_ptr()) })
+    }
+
+    pub fn add_user(
+        &mut self,
+        user: &str,
+        extra_msg: &str,
+        flags: PurpleConvChatBuddyFlags,
+        new_arrival: bool,
+    ) {
+        let c_user = CString::new(user).unwrap();
+        let c_extra_msg = CString::new(extra_msg).unwrap();
+        log::info!(
+            "{:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}",
+            self.as_mut_ptr(),
+            c_user,
+            c_user.as_ptr(),
+            c_extra_msg,
+            c_extra_msg.as_ptr(),
+            flags,
+            new_arrival.to_glib()
+        );
+        unsafe {
+            purple_sys::purple_conv_chat_add_user(
+                self.as_mut_ptr(),
+                c_user.as_ptr(),
+                c_extra_msg.as_ptr(),
+                flags,
+                new_arrival.to_glib(),
+            )
+        }
+        log::info!("Added user");
+    }
+
+    pub fn clear_users(&mut self) {
+        unsafe { purple_sys::purple_conv_chat_clear_users(self.as_mut_ptr()) }
+    }
+
+    pub fn get_conversation(&mut self) -> Conversation {
+        unsafe {
+            Conversation::from_ptr(purple_sys::purple_conv_chat_get_conversation(
+                self.as_mut_ptr(),
+            ))
+            .unwrap()
+        }
+    }
+}
+
+impl AsPtr for Conversation {
+    type PtrType = purple_sys::PurpleConversation;
+    fn as_ptr(&self) -> *const Self::PtrType {
+        self.0.as_ptr()
+    }
+}
 impl AsPtr for ChatConversation {
     type PtrType = purple_sys::PurpleConvChat;
     fn as_ptr(&self) -> *const Self::PtrType {

--- a/src/purple/handlers/traits.rs
+++ b/src/purple/handlers/traits.rs
@@ -1,6 +1,5 @@
 use super::super::{
-    prpl, Account, ChatConversation, Connection, Plugin, PurpleMessageFlags, StatusType,
-    StrHashTable,
+    prpl, Account, Connection, Conversation, Plugin, PurpleMessageFlags, StatusType, StrHashTable,
 };
 use std::ffi::CStr;
 
@@ -48,6 +47,10 @@ pub trait ConvoClosedHandler {
     fn convo_closed(&mut self, connection: &mut Connection, who: Option<&str>);
 }
 
+pub trait GetChatBuddyAlias {
+    fn get_cb_alias(&mut self, connection: &mut Connection, id: i32, who: &str) -> Option<String>;
+}
+
 pub trait GetChatNameHandler {
     fn get_chat_name(data: Option<&mut StrHashTable>) -> Option<String>;
 }
@@ -93,7 +96,7 @@ pub trait InputHandler {
 pub trait CommandHandler {
     fn command(
         &mut self,
-        conversation: &mut ChatConversation,
+        conversation: &mut Conversation,
         command: &str,
         args: &[&str],
     ) -> purple_sys::PurpleCmdRet;

--- a/src/purple/loader.rs
+++ b/src/purple/loader.rs
@@ -134,4 +134,5 @@ impl_extra_handler_builder! {
     get_chat_name => GetChatNameHandler
     send_im => SendIMHandler
     chat_send => ChatSendHandler
+    get_cb_alias => GetChatBuddyAlias
 }


### PR DESCRIPTION
@aviau for review!

In short, I added `ChatInfo` and `PartialChatInfo`. When we joined a chat based on events we actually use `PartialChatInfo`. We also pass the info version (As sent by the API) if available, such that we can't compare with the chat data if we need to re-fetch the chat info. In that case we do the GetChatInfo query and then end up in `load_chat_info` which actually take in a `ChatInfo` and fill in all fields such as members and maybe more in the future (topics? rules?).

Closes #37 