### PR TITLE
Use sn as sender name to let purple use the alias

### DIFF
--- a/src/icq/client/mod.rs
+++ b/src/icq/client/mod.rs
@@ -224,10 +224,11 @@ pub struct ChatInfoResponseMember {
     #[serde(default)]
     pub user_state: ChatInfoResponseMemberUserState,
     pub friendly: Option<String>,
+    #[serde(default)]
     pub anketa: ChatInfoResponseMemberAnketa,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatInfoResponseMemberAnketa {
     pub first_name: Option<String>,

--- a/src/purple/connection/mod.rs
+++ b/src/purple/connection/mod.rs
@@ -64,12 +64,7 @@ impl Connection {
         unsafe {
             let c_sn = CString::new(chat_input.chat_sn).unwrap();
             let sn_hash = glib_sys::g_str_hash(c_sn.as_ptr() as *mut c_void);
-            let who = if chat_input.author_friendly == chat_input.author_sn {
-                chat_input.author_friendly
-            } else {
-                format!("{}!{}", chat_input.author_sn, chat_input.author_friendly)
-            };
-            let c_sender = CString::new(who).unwrap();
+            let c_sender = CString::new(chat_input.author_sn).unwrap();
             let c_text = CString::new(chat_input.text).unwrap();
 
             purple_sys::serv_got_chat_in(


### PR DESCRIPTION
@aviau for review!

Plutôt que faire notre hack on laisse purple faire la job ;)

Aussi, petit fix dans le modèle des données qu'on recoit suite à des erreurs lors de mes tests.